### PR TITLE
Add dockerfile and docker-compose for api and postgres db

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /app
+COPY Adapters/Drivers/DotLanches.Api/*.csproj ./Adapters/Drivers/DotLanches.Api/
+COPY Adapters/Drivens/DotLanches.Infra/*.csproj ./Adapters/Drivers/DotLanches.Infra/
+COPY Core/DotLanches.Application/*.csproj ./Core/DotLanches.Application/
+COPY Core/DotLanches.Domain/*.csproj ./Core/DotLanches.Domain/
+RUN dotnet restore "Adapters/Drivers/DotLanches.Api/DotLanches.Api.csproj"
+COPY . .
+RUN dotnet publish "Adapters/Drivers/DotLanches.Api/DotLanches.Api.csproj" -c Release -o out
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/out ./
+ENTRYPOINT ["dotnet", "DotLanches.Api.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.9'
+
+volumes:
+  dotLanchesDb:
+    name: "dotLanchesDb"
+
+networks:
+  dotLanchesNetwork:
+    driver: bridge
+
+services:
+  db:
+    image: postgres:16.3-alpine3.18
+    container_name: dotlanches_db
+    restart: always
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: dotLanches
+    ports:
+      - "5432:5432"
+    volumes:
+      - dotLanchesDb:/var/lib/postgresql/data
+    networks:
+      - dotLanchesNetwork
+
+  api:
+    build: .
+    container_name: dotlanches_api
+    restart: always
+    depends_on:
+      - db
+    ports:
+      - "8080:8080"
+    environment:
+      - ConnectionStrings__DefaultConnection=Host=db;Port=5432;Database=dotLanches;Username=${POSTGRES_USER};Password=${POSTGRES_PASSWORD}
+    networks:
+      - dotLanchesNetwork


### PR DESCRIPTION
- Docker Compose file for creating postgre DB container and app container.
- Dockerfile for building and starting web api.
- Database environment credentials are defined in .env file (not submited in this commit).