### PR TITLE
Payment routes for qr code request (mocked) and payment confirmation

### DIFF
--- a/Core/DotLanches.Application/UseCases/PagamentoUseCases.cs
+++ b/Core/DotLanches.Application/UseCases/PagamentoUseCases.cs
@@ -17,7 +17,7 @@ namespace DotLanches.Application.UseCases
             await pagamentoGateway.Add(pagamento);
 
             //Fake Checkout for current version
-            var qrCode = checkout.ProcessPayment(pagamento);
+            var qrCode = checkout.RequestQrCode(pagamento);
 
             return qrCode;
         }

--- a/Core/DotLanches.Application/UseCases/PagamentoUseCases.cs
+++ b/Core/DotLanches.Application/UseCases/PagamentoUseCases.cs
@@ -6,7 +6,7 @@ namespace DotLanches.Application.UseCases
 {
     public static class PagamentoUseCases
     {
-        public static async Task<Pagamento> ProcessPagamento(int idPedido, IPedidoGateway pedidoGateway, IPagamentoGateway pagamentoGateway, ICheckout checkout)
+        public static async Task<string> ProcessPagamento(int idPedido, IPedidoGateway pedidoGateway, IPagamentoGateway pagamentoGateway, ICheckout checkout)
         {
             var pedido = await pedidoGateway.GetById(idPedido) ??
                 throw new Exception("Payment processing error: Non existing pedido!");
@@ -15,16 +15,43 @@ namespace DotLanches.Application.UseCases
             await pagamentoGateway.Add(pagamento);
 
             //Fake Checkout for current version
-            var paymentSucceded = checkout.ProcessPayment(pagamento);
+            var qrCode = checkout.ProcessPayment(pagamento);
 
-            if (paymentSucceded)
-            {
-                pagamento.ConfirmPayment();
-                pedido.ReceivePagamento();
+            return qrCode;
+        }
 
-                await pedidoGateway.Update(pedido);
-                pagamento = await pagamentoGateway.Update(pagamento);
-            }
+        public static async Task<Pagamento> AcceptedPagamento(int idPedido, IPedidoGateway pedidoGateway, IPagamentoGateway pagamentoGateway)
+        {
+            var pedido = await pedidoGateway.GetById(idPedido) ??
+                throw new Exception("Payment processing error: Non existing pedido!");
+
+            var pagamento = new Pagamento(pedido.Id);
+
+            await pagamentoGateway.Add(pagamento);
+
+            pagamento.ConfirmPayment();
+
+            pedido.ReceivePagamento();
+
+            await pedidoGateway.Update(pedido);
+
+            pagamento = await pagamentoGateway.Update(pagamento);
+
+            return pagamento;
+        }
+
+        public static async Task<Pagamento> RefusedPagamento(int idPedido, IPedidoGateway pedidoGateway, IPagamentoGateway pagamentoGateway)
+        {
+            var pedido = await pedidoGateway.GetById(idPedido) ??
+                throw new Exception("Payment processing error: Non existing pedido!");
+
+            var pagamento = new Pagamento(pedido.Id);
+
+            await pagamentoGateway.Add(pagamento);
+
+            pagamento.RefusePayment();
+
+            pagamento = await pagamentoGateway.Update(pagamento);
 
             return pagamento;
         }

--- a/Core/DotLanches.Application/UseCases/PagamentoUseCases.cs
+++ b/Core/DotLanches.Application/UseCases/PagamentoUseCases.cs
@@ -11,6 +11,8 @@ namespace DotLanches.Application.UseCases
             var pedido = await pedidoGateway.GetById(idPedido) ??
                 throw new Exception("Payment processing error: Non existing pedido!");
 
+            if (pedido.Status.Id != 1) throw new Exception("Payment processing error: Pedido not confirmed!");
+
             var pagamento = new Pagamento(pedido.Id);
             await pagamentoGateway.Add(pagamento);
 
@@ -24,6 +26,8 @@ namespace DotLanches.Application.UseCases
         {
             var pedido = await pedidoGateway.GetById(idPedido) ??
                 throw new Exception("Payment processing error: Non existing pedido!");
+
+            if (pedido.Status.Id != 1) throw new Exception("Payment processing error: Pedido not confirmed!");
 
             var pagamento = new Pagamento(pedido.Id);
 
@@ -44,6 +48,8 @@ namespace DotLanches.Application.UseCases
         {
             var pedido = await pedidoGateway.GetById(idPedido) ??
                 throw new Exception("Payment processing error: Non existing pedido!");
+
+            if (pedido.Status.Id != 1) throw new Exception("Payment processing error: Pedido not confirmed!");
 
             var pagamento = new Pagamento(pedido.Id);
 

--- a/Core/DotLanches.Application/UseCases/PagamentoUseCases.cs
+++ b/Core/DotLanches.Application/UseCases/PagamentoUseCases.cs
@@ -6,7 +6,7 @@ namespace DotLanches.Application.UseCases
 {
     public static class PagamentoUseCases
     {
-        public static async Task<string> ProcessPagamento(int idPedido, IPedidoGateway pedidoGateway, IPagamentoGateway pagamentoGateway, ICheckout checkout)
+        public static async Task<string> RequestQrCodeForPedido(int idPedido, IPedidoGateway pedidoGateway, IPagamentoGateway pagamentoGateway, ICheckout checkout)
         {
             var pedido = await pedidoGateway.GetById(idPedido) ??
                 throw new Exception("Payment processing error: Non existing pedido!");

--- a/Core/DotLanches.Domain/Entities/Pedido.cs
+++ b/Core/DotLanches.Domain/Entities/Pedido.cs
@@ -49,4 +49,9 @@ public class Pedido
         this.Status = Status.Recebido();
     }
 
+    public void Cancel()
+    {
+        this.Status = Status.Cancelado();
+    }
+
 }

--- a/Core/DotLanches.Domain/Interfaces/ExternalInterfaces/ICheckout.cs
+++ b/Core/DotLanches.Domain/Interfaces/ExternalInterfaces/ICheckout.cs
@@ -4,6 +4,6 @@ namespace DotLanches.Domain.Interfaces.ExternalInterfaces
 {
     public interface ICheckout
     {
-        string ProcessPayment(Pagamento pagamento);
+        string RequestQrCode(Pagamento pagamento);
     }
 }

--- a/Core/DotLanches.Domain/Interfaces/ExternalInterfaces/ICheckout.cs
+++ b/Core/DotLanches.Domain/Interfaces/ExternalInterfaces/ICheckout.cs
@@ -4,6 +4,6 @@ namespace DotLanches.Domain.Interfaces.ExternalInterfaces
 {
     public interface ICheckout
     {
-        bool ProcessPayment(Pagamento pagamento);
+        string ProcessPayment(Pagamento pagamento);
     }
 }

--- a/FrameworksAndDrivers/ExternalInterfaces/DotLanches.Payment/FakeCheckout/FakeCheckout.cs
+++ b/FrameworksAndDrivers/ExternalInterfaces/DotLanches.Payment/FakeCheckout/FakeCheckout.cs
@@ -5,9 +5,12 @@ namespace DotLanches.Payment.FakeCheckout
 {
     public class FakeCheckout : ICheckout
     {
-        public bool ProcessPayment(Pagamento pagamento)
+        public string ProcessPayment(Pagamento pagamento)
         {
-            return true;
+            //proccess time - 3s
+            Thread.Sleep(3000);
+            if (pagamento == null) return String.Empty;
+            return "DecodedQRCode";
         }
     }
 }

--- a/FrameworksAndDrivers/ExternalInterfaces/DotLanches.Payment/FakeCheckout/FakeCheckout.cs
+++ b/FrameworksAndDrivers/ExternalInterfaces/DotLanches.Payment/FakeCheckout/FakeCheckout.cs
@@ -5,7 +5,7 @@ namespace DotLanches.Payment.FakeCheckout
 {
     public class FakeCheckout : ICheckout
     {
-        public string ProcessPayment(Pagamento pagamento)
+        public string RequestQrCode(Pagamento pagamento)
         {
             //proccess time - 3s
             Thread.Sleep(3000);

--- a/FrameworksAndDrivers/Web/DotLanches.Api/Controllers/PagamentoController.cs
+++ b/FrameworksAndDrivers/Web/DotLanches.Api/Controllers/PagamentoController.cs
@@ -28,16 +28,32 @@ namespace DotLanches.Api.Controllers
         /// Envia os dados para o meio de pagamento e retorna a senha para retirar o pedido.
         /// </summary>
         /// <param name="pagamentoRequest">Dados de requisição do pagamento</param>
-        /// <returns>Situação do pagamento e senha para retirada do pedido.</returns>
-        [HttpPost]
-        [ProducesResponseType(typeof(PagamentoViewModel), StatusCodes.Status200OK)]
+        /// <returns>QR Code para efetuar pagamento.</returns>
+        [HttpPost("QrCode")]
+        [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
         public async Task<IActionResult> ExecutePayment([Required][FromBody] PagamentoRequestDto pagamentoRequest)
         {
             var adapterPagamento = new AdapterPagamentoController(_pagamentoRepository, _pedidoRepository, _checkout);
-            var queueKey = await _pedidoRepository.AssignKey(pagamentoRequest.IdPedido);
-            var payResponse = await adapterPagamento.ProcessPagamento(pagamentoRequest.IdPedido, queueKey);
+            var qrCode = await adapterPagamento.ProcessPagamento(pagamentoRequest.IdPedido);
+            return Ok(qrCode);
+        }
+
+        /// <summary>
+        /// Recebe o status do pagamento e segue com a confirmação ou cancelamento do pedido.
+        /// </summary>
+        /// <param name="pagamentoResponse">Dados de requisição do pagamento</param>
+        /// <returns>Situação do pagamento e senha para retirada do pedido.</returns>
+        [HttpPost("Confirmar")]
+        [ProducesResponseType(typeof(PagamentoViewModel), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> PaymentResponseHandler([Required][FromBody] PagamentoResponseDto pagamentoResponse)
+        {
+            var adapterPagamento = new AdapterPagamentoController(_pagamentoRepository, _pedidoRepository, _checkout);
+            var queueKey = pagamentoResponse.PaymentStatus ? await _pedidoRepository.AssignKey(pagamentoResponse.IdPedido) : 0;
+            var payResponse = await adapterPagamento.ConfirmPagamento(pagamentoResponse.IdPedido, pagamentoResponse.PaymentStatus, queueKey);
             return Ok(payResponse);
         }
     }

--- a/FrameworksAndDrivers/Web/DotLanches.Api/Controllers/PagamentoController.cs
+++ b/FrameworksAndDrivers/Web/DotLanches.Api/Controllers/PagamentoController.cs
@@ -49,7 +49,7 @@ namespace DotLanches.Api.Controllers
         [ProducesResponseType(typeof(PagamentoViewModel), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> PaymentResponseHandler([Required][FromBody] PagamentoResponseDto pagamentoResponse)
+        public async Task<IActionResult> ProcessPagamento([Required][FromBody] PagamentoResponseDto pagamentoResponse)
         {
             var adapterPagamento = new AdapterPagamentoController(_pagamentoRepository, _pedidoRepository, _checkout);
             var queueKey = pagamentoResponse.PaymentStatus ? await _pedidoRepository.AssignKey(pagamentoResponse.IdPedido) : 0;

--- a/FrameworksAndDrivers/Web/DotLanches.Api/Controllers/PagamentoController.cs
+++ b/FrameworksAndDrivers/Web/DotLanches.Api/Controllers/PagamentoController.cs
@@ -25,7 +25,7 @@ namespace DotLanches.Api.Controllers
         }
 
         /// <summary>
-        /// Envia os dados para o meio de pagamento e retorna a senha para retirar o pedido.
+        /// Envia os dados para o meio de pagamento e retorna o QR Code para o cliente.
         /// </summary>
         /// <param name="pagamentoRequest">Dados de requisição do pagamento</param>
         /// <returns>QR Code para efetuar pagamento.</returns>

--- a/FrameworksAndDrivers/Web/DotLanches.Api/Controllers/PagamentoController.cs
+++ b/FrameworksAndDrivers/Web/DotLanches.Api/Controllers/PagamentoController.cs
@@ -36,7 +36,7 @@ namespace DotLanches.Api.Controllers
         public async Task<IActionResult> RequestPagamentoQrCode([Required][FromBody] PagamentoRequestDto pagamentoRequest)
         {
             var adapterPagamento = new AdapterPagamentoController(_pagamentoRepository, _pedidoRepository, _checkout);
-            var qrCode = await adapterPagamento.ProcessPagamento(pagamentoRequest.IdPedido);
+            var qrCode = await adapterPagamento.RequestPagamentoQRCode(pagamentoRequest.IdPedido);
             return Ok(qrCode);
         }
 
@@ -49,11 +49,11 @@ namespace DotLanches.Api.Controllers
         [ProducesResponseType(typeof(PagamentoViewModel), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> ProcessPagamento([Required][FromBody] PagamentoResponseDto pagamentoResponse)
+        public async Task<IActionResult> ProcessPagamento([Required][FromBody] ProcessPagamentoRequestDto pagamentoResponse)
         {
             var adapterPagamento = new AdapterPagamentoController(_pagamentoRepository, _pedidoRepository, _checkout);
-            var queueKey = pagamentoResponse.PaymentStatus ? await _pedidoRepository.AssignKey(pagamentoResponse.IdPedido) : 0;
-            var payResponse = await adapterPagamento.ConfirmPagamento(pagamentoResponse.IdPedido, pagamentoResponse.PaymentStatus, queueKey);
+            var queueKey = pagamentoResponse.IsAccepted ? await _pedidoRepository.AssignKey(pagamentoResponse.IdPedido) : 0;
+            var payResponse = await adapterPagamento.ProcessPagamento(pagamentoResponse.IdPedido, pagamentoResponse.IsAccepted, queueKey);
             return Ok(payResponse);
         }
     }

--- a/FrameworksAndDrivers/Web/DotLanches.Api/Controllers/PagamentoController.cs
+++ b/FrameworksAndDrivers/Web/DotLanches.Api/Controllers/PagamentoController.cs
@@ -33,7 +33,7 @@ namespace DotLanches.Api.Controllers
         [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
-        public async Task<IActionResult> ExecutePayment([Required][FromBody] PagamentoRequestDto pagamentoRequest)
+        public async Task<IActionResult> RequestPagamentoQrCode([Required][FromBody] PagamentoRequestDto pagamentoRequest)
         {
             var adapterPagamento = new AdapterPagamentoController(_pagamentoRepository, _pedidoRepository, _checkout);
             var qrCode = await adapterPagamento.ProcessPagamento(pagamentoRequest.IdPedido);

--- a/FrameworksAndDrivers/Web/DotLanches.Api/Dtos/PagamentoResponseDto.cs
+++ b/FrameworksAndDrivers/Web/DotLanches.Api/Dtos/PagamentoResponseDto.cs
@@ -4,5 +4,5 @@ public class ProcessPagamentoRequestDto
 {
     public int IdPedido { get; set; }
 
-    public bool PaymentStatus { get; set; }
+    public bool IsAccepted { get; set; }
 }

--- a/FrameworksAndDrivers/Web/DotLanches.Api/Dtos/PagamentoResponseDto.cs
+++ b/FrameworksAndDrivers/Web/DotLanches.Api/Dtos/PagamentoResponseDto.cs
@@ -1,6 +1,6 @@
 ﻿namespace DotLanches.Api.Dtos;
 
-public class PagamentoResponseDto
+public class ProcessPagamentoRequestDto
 {
     public int IdPedido { get; set; }
 

--- a/FrameworksAndDrivers/Web/DotLanches.Api/Dtos/PagamentoResponseDto.cs
+++ b/FrameworksAndDrivers/Web/DotLanches.Api/Dtos/PagamentoResponseDto.cs
@@ -1,0 +1,8 @@
+﻿namespace DotLanches.Api.Dtos;
+
+public class PagamentoResponseDto
+{
+    public int IdPedido { get; set; }
+
+    public bool PaymentStatus { get; set; }
+}

--- a/InterfaceAdapters/Controllers/DotLanches.Controllers/AdapterPagamentoController.cs
+++ b/InterfaceAdapters/Controllers/DotLanches.Controllers/AdapterPagamentoController.cs
@@ -29,7 +29,7 @@ namespace DotLanches.Controllers
             return qrCode;
         }
 
-        public async Task<PagamentoViewModel?> ConfirmPagamento(int idPedido, bool isAccepted, int queueKey)
+        public async Task<PagamentoViewModel?> ProcessPagamento(int idPedido, bool isAccepted, int queueKey)
         {
             var pedidoGateway = new PedidoGateway(_pedidoRepository);
             var pagamentoGateway = new PagamentoGateway(_pagamentoRepository);

--- a/InterfaceAdapters/Controllers/DotLanches.Controllers/AdapterPagamentoController.cs
+++ b/InterfaceAdapters/Controllers/DotLanches.Controllers/AdapterPagamentoController.cs
@@ -24,7 +24,7 @@ namespace DotLanches.Controllers
         {
             var pedidoGateway = new PedidoGateway(_pedidoRepository);
             var pagamentoGateway = new PagamentoGateway(_pagamentoRepository);
-            var qrCode = await PagamentoUseCases.ProcessPagamento(idPedido, pedidoGateway, pagamentoGateway, _checkout);
+            var qrCode = await PagamentoUseCases.RequestQrCodeForPedido(idPedido, pedidoGateway, pagamentoGateway, _checkout);
 
             return qrCode;
         }

--- a/InterfaceAdapters/Controllers/DotLanches.Controllers/AdapterPagamentoController.cs
+++ b/InterfaceAdapters/Controllers/DotLanches.Controllers/AdapterPagamentoController.cs
@@ -20,7 +20,7 @@ namespace DotLanches.Controllers
             _checkout = checkout;
         }
 
-        public async Task<String> ProcessPagamento(int idPedido)
+        public async Task<String> RequestPagamentoQRCode(int idPedido)
         {
             var pedidoGateway = new PedidoGateway(_pedidoRepository);
             var pagamentoGateway = new PagamentoGateway(_pagamentoRepository);

--- a/InterfaceAdapters/Controllers/DotLanches.Controllers/AdapterPagamentoController.cs
+++ b/InterfaceAdapters/Controllers/DotLanches.Controllers/AdapterPagamentoController.cs
@@ -20,13 +20,31 @@ namespace DotLanches.Controllers
             _checkout = checkout;
         }
 
-        public async Task<PagamentoViewModel?> ProcessPagamento(int idPedido, int queueKey)
+        public async Task<String> ProcessPagamento(int idPedido)
         {
             var pedidoGateway = new PedidoGateway(_pedidoRepository);
             var pagamentoGateway = new PagamentoGateway(_pagamentoRepository);
-            var payResponse = await PagamentoUseCases.ProcessPagamento(idPedido, pedidoGateway, pagamentoGateway, _checkout);
+            var qrCode = await PagamentoUseCases.ProcessPagamento(idPedido, pedidoGateway, pagamentoGateway, _checkout);
 
-            return PagamentoPresenter.GetPagamentoViewModel(payResponse, queueKey);
+            return qrCode;
+        }
+
+        public async Task<PagamentoViewModel?> ConfirmPagamento(int idPedido, bool isAccepted, int queueKey)
+        {
+            var pedidoGateway = new PedidoGateway(_pedidoRepository);
+            var pagamentoGateway = new PagamentoGateway(_pagamentoRepository);
+
+            if (isAccepted)
+            {
+                var payResponse = await PagamentoUseCases.AcceptedPagamento(idPedido, pedidoGateway, pagamentoGateway);
+                return PagamentoPresenter.GetPagamentoViewModel(payResponse, queueKey);
+            }
+            else
+            {
+                var payResponse = await PagamentoUseCases.RefusedPagamento(idPedido, pedidoGateway, pagamentoGateway);
+                return PagamentoPresenter.GetPagamentoViewModel(payResponse);
+            }
+
         }
     }
 }


### PR DESCRIPTION
- Payment has 2 routes for requesting external service QR-Code and receiving its acceptance/denial response;
- QR-Code gen mocked in FakeCheckout;
- Payment denial causes order status to change to canceled;
- QueueKey number and AddedToQueue timestamp only created when payment is accepted. 